### PR TITLE
[coremarkers] update + [scoreboard] default settings update

### DIFF
--- a/resources/[gameplay]/scoreboard/dxscoreboard_clientsettings.lua
+++ b/resources/[gameplay]/scoreboard/dxscoreboard_clientsettings.lua
@@ -146,9 +146,9 @@ fontIndexes = {
 fontNames = { "default", "default-bold", "clear", "arial", "sans","pricedown", "bankgothic", "diploma", "beckett" }
 
 function readScoreboardSettings()
-	local settingsFile = xmlLoadFile( "@settings.xml" )
+	local settingsFile = xmlLoadFile( "settings-mrgreen.xml" )
 	if not settingsFile then
-		settingsFile = xmlCreateFile( "@settings.xml", "settings" )
+		settingsFile = xmlCreateFile( "settings-mrgreen.xml", "settings" )
 		if not settingsFile then return false end
 		
 		local useanimationTag = xmlCreateChild( settingsFile, "useanimation" )

--- a/resources/[gameplay]/scoreboard/dxscoreboard_clientsettings.lua
+++ b/resources/[gameplay]/scoreboard/dxscoreboard_clientsettings.lua
@@ -146,9 +146,9 @@ fontIndexes = {
 fontNames = { "default", "default-bold", "clear", "arial", "sans","pricedown", "bankgothic", "diploma", "beckett" }
 
 function readScoreboardSettings()
-	local settingsFile = xmlLoadFile( "settings-mrgreen.xml" )
+	local settingsFile = xmlLoadFile( "@settings.xml" )
 	if not settingsFile then
-		settingsFile = xmlCreateFile( "settings-mrgreen.xml", "settings" )
+		settingsFile = xmlCreateFile( "@settings.xml", "settings" )
 		if not settingsFile then return false end
 		
 		local useanimationTag = xmlCreateChild( settingsFile, "useanimation" )

--- a/resources/[gameplay]/scoreboard/dxscoreboard_clientsettings.lua
+++ b/resources/[gameplay]/scoreboard/dxscoreboard_clientsettings.lua
@@ -21,9 +21,9 @@ settings = {
 	["content_color"] = {}
 }
 defaultSettings = {
-	["useanimation"] = true,
+	["useanimation"] = false,
 	["toggleable"] = false,
-	["showserverinfo"] = false,
+	["showserverinfo"] = true,
 	["showgamemodeinfo"] = false,
 	["showteams"] = true,
 	["usecolors"] = true,
@@ -70,9 +70,9 @@ defaultSettings = {
 		["a"] = 50
 	},
 	["serverinfo_color"] = {
-		["r"] = 150,
-		["g"] = 150,
-		["b"] = 150,
+		["r"] = 0,
+		["g"] = 255,
+		["b"] = 0,
 		["a"] = 255
 	},
 	["content_color"] = {
@@ -146,9 +146,9 @@ fontIndexes = {
 fontNames = { "default", "default-bold", "clear", "arial", "sans","pricedown", "bankgothic", "diploma", "beckett" }
 
 function readScoreboardSettings()
-	local settingsFile = xmlLoadFile( "settings.xml" )
+	local settingsFile = xmlLoadFile( "settings-mrgreen.xml" )
 	if not settingsFile then
-		settingsFile = xmlCreateFile( "settings.xml", "settings" )
+		settingsFile = xmlCreateFile( "settings-mrgreen.xml", "settings" )
 		if not settingsFile then return false end
 		
 		local useanimationTag = xmlCreateChild( settingsFile, "useanimation" )
@@ -863,9 +863,9 @@ function restoreDefaultSettings()
 end
 
 function saveSettings( settingsTable )
-	local settingsFile = xmlLoadFile( "settings.xml" )
+	local settingsFile = xmlLoadFile( "settings-mrgreen.xml" )
 	if not settingsFile then
-		settingsFile = xmlCreateFile( "settings.xml", "settings" )
+		settingsFile = xmlCreateFile( "settings-mrgreen.xml", "settings" )
 		if not settingsFile then return false end
 		local useanimationTag = xmlCreateChild( settingsFile, "useanimation" )
 		local toggleableTag = xmlCreateChild( settingsFile, "toggleable" )

--- a/resources/[maps]/coremarkers/chatbar_c.lua
+++ b/resources/[maps]/coremarkers/chatbar_c.lua
@@ -17,7 +17,7 @@ local DefaultTime = 8; 		-- The max time each message will show if time isn't de
 -- For scripters only					--
 ------------------------------------------
 local sx_, sy_ = guiGetScreenSize ( )
-local sx, sy = sx_/1280, sy_/1080 -- you got xXMADEXx's resolution :3 plz no hak mi
+local sx, sy = sx_/1920, sy_/1080 -- you got xXMADEXx's resolution :3 plz no hak mi
 local DefaultPos = true;
 local messages_top = { }
 local messages_btm = { }
@@ -81,7 +81,7 @@ function dxDrawNotificationBar ( )
 			end
 		end
 		dxDrawRectangle ( (sx_/2-530/2), i*25, 530, 25, tocolor ( 0, 0, 0, v.alpha ) )
-		dxDrawText ( tostring ( v.message ), 0, i*25, sx_, (i+1)*25, tocolor ( v.r, v.g, v.b, v.alpha*1.59375 ), sy*1, "default-bold", "center", "center", false, false, false, true)
+		dxDrawText ( tostring ( v.message ), 0, i*25, sx_, (i+1)*25, tocolor ( v.r, v.g, v.b, v.alpha*1.59375 ), sy*1.3, "clear", "center", "center", false, false, false, true)
 	end 
 	if ( #messages_top > maxMessages and messages_top[1].locked ) then
 		messages_top[1].locked = false
@@ -105,8 +105,10 @@ function dxDrawNotificationBar ( )
 				messages_btm[i].locked=false
 			end
 		end
-		dxDrawRectangle ( (sx_/2-530/2), sy_-(i*25), 530, 25, tocolor ( 0, 0, 0, v.alpha ) )
-		dxDrawText ( tostring ( v.message ), 0, sy_-(i*25), sx_, sy_-((i-1)*25), tocolor ( v.r, v.g, v.b, v.alpha*1.59375 ), sy*1, "default-bold", "center", "center", false, false, false, true)
+		
+		local textWidth = dxGetTextWidth(tostring ( v.message ), sy*1.5, "clear", true)+10*sx
+		dxDrawRectangle ( (sx_/2-textWidth/2), sy_-(i*27*sy), textWidth, 27*sy, tocolor ( 0, 0, 0, v.alpha ) )
+		dxDrawText ( tostring ( v.message ), 0, sy_-(i*27*sy), sx_, sy_-((i-1)*27*sy), tocolor ( v.r, v.g, v.b, v.alpha*1.59375 ), sy*1.5, "clear", "center", "center", false, false, false, true, true)
 	end 
 	if ( #messages_btm > maxMessages and messages_btm[1].locked ) then
 		messages_btm[1].locked = false

--- a/resources/[maps]/coremarkers/client.lua
+++ b/resources/[maps]/coremarkers/client.lua
@@ -37,7 +37,7 @@ end
 function getRandomPower()
 playSound("marker.mp3")
 local randomPower = unpack(powerTypes[math.random(#powerTypes)])
---local randomPower = "barrels"
+local randomPower = "rocket"
 	
 	if math.random(150) == math.random(150) then
 		bindKeys("magnet")
@@ -86,9 +86,9 @@ unbindKeys()
 		local z = getGroundPosition(x, y, z)		
 		triggerServerEvent("dropSpikes", resourceRoot, localPlayer, x, y, z, rz)
 	elseif powerType == "boost" then
-		local engineAcc = getVehicleOriginalProperty(theVehicle, "engineAcceleration")
+		local engineAcc = getVehicleOriginalProperty(theVehicle, "engineAcceleration")*2.5
 		if engineAcc >= 25 then
-			setElementSpeed(theVehicle, "kmh", 300)
+			setElementSpeed(theVehicle, "kmh", 290)
 		else
 			setElementSpeed(theVehicle, "kmh", 260)
 		end
@@ -100,7 +100,7 @@ unbindKeys()
 			setElementData(localPlayer, "boostx3", boost)
 			local engineAcc = getVehicleOriginalProperty(theVehicle, "engineAcceleration")*2.5
 			if engineAcc >= 25 then
-				setElementSpeed(theVehicle, "kmh", 300)
+				setElementSpeed(theVehicle, "kmh", 290)
 			else
 				setElementSpeed(theVehicle, "kmh", 260)
 			end
@@ -136,7 +136,7 @@ unbindKeys()
 		local z = getGroundPosition(x, y, z)
 		triggerServerEvent("dropBarrels", resourceRoot, 1225, x, y, z, rz)
 	elseif powerType == "repair" then
-		triggerServerEvent("fixVehicle", resourceRoot, theVehicle)
+		triggerServerEvent("fixVehicle", resourceRoot, localPlayer, theVehicle, true)
 	end
 end
 
@@ -178,7 +178,7 @@ addEventHandler( "onClientRender",  root,
 				dxDrawRectangle(1021*sWidth/1920, 898*sHeight/1080, 18*sWidth/1920, 172*sHeight/1080, tocolor(0, 0, 0, 180))
 				dxDrawRectangle(1022*sWidth/1920, 899*sHeight/1080, 16*sWidth/1920, 170*sHeight/1080, tocolor(0, 0, 0, 200))
 				dxDrawRectangle(1023*sWidth/1920, 900*sHeight/1080, 14*sWidth/1920, 168*sHeight/1080, tocolor(0, 255, 0, 200))
-				dxDrawRectangle(1023*sWidth/1920, 900*sHeight/1080, 14*sWidth/1920, timeLeft/spikesRepairTime*168*sHeight/1080, tocolor(30, 30, 30, 200))
+				dxDrawRectangle(1023*sWidth/1920, 900*sHeight/1080, 14*sWidth/1920, timeLeft/10000*168*sHeight/1080, tocolor(30, 30, 30, 200))
 			end
 		end
 		
@@ -235,9 +235,19 @@ end
 addEvent('createExplosionEffect', true)
 addEventHandler('createExplosionEffect', root, createExplosionEffect)
 
-function spikesTimerFunction(timems)
-spikesRepairTime = timems
-spikesTimer = setTimer(function() setElementData(localPlayer, "rektBySpikes", false, true) playSoundFrontEnd(46) end, timems, 1)
+function spikesTimerFunction()
+	if isTimer(spikesTimer) then
+		killTimer(spikesTimer)
+	end
+	spikesTimer = setTimer(function() 
+		setElementData(localPlayer, "rektBySpikes", false, true) 
+		local theVehicle = getPedOccupiedVehicle(localPlayer)
+		local s1, _, _, _ = getVehicleWheelStates(theVehicle)
+		if s1 ~= 0 then
+			playSoundFrontEnd(46)
+			triggerServerEvent("fixVehicle", resourceRoot, localPlayer, theVehicle, false)
+		end 
+	end, 10000, 1)
 end
 addEvent("spikesTimerFunction", true)
 addEventHandler("spikesTimerFunction", root, spikesTimerFunction)

--- a/resources/[maps]/coremarkers/client.lua
+++ b/resources/[maps]/coremarkers/client.lua
@@ -37,7 +37,7 @@ end
 function getRandomPower()
 playSound("marker.mp3")
 local randomPower = unpack(powerTypes[math.random(#powerTypes)])
-local randomPower = "rocket"
+--local randomPower = "rocket"
 	
 	if math.random(150) == math.random(150) then
 		bindKeys("magnet")

--- a/resources/[maps]/coremarkers/server.lua
+++ b/resources/[maps]/coremarkers/server.lua
@@ -4,7 +4,7 @@ math.randomseed(getTickCount())
 
 addEventHandler("onResourceStart", resourceRoot, 
 function()
-outputChatBox( '#ffffff"Core Markers" by #00dd22AleksCore #fffffflaunched.', killer, 255, 0, 0, true)
+outputChatBox( '#ffffff"Core Markers" by #00dd22AleksCore #fffffflaunched.', root, 255, 0, 0, true)
 showText_Create()
 showText( 54, 201, 46, "Pick-up power-ups\n @\n Press Fire button", 12000, all)
 setTimer(function() textItemSetColor(showText_Text, 54, 201, 46, 255) setTimer(function() textItemSetColor(showText_Text, 255, 255, 255, 255) end, 600, 1) end, 1000, 11)
@@ -70,12 +70,7 @@ function dropSpikes(creator, x, y, z, rz)
 					if pz >= sz then
 						setVehicleWheelStates(getPedOccupiedVehicle(thePlayer), 1, 1, 1, 1)
 						setElementData(thePlayer, "rektBySpikes", true, true)
-						triggerClientEvent(thePlayer, "spikesTimerFunction", root, 10000)
-						spikesTimer = setTimer(function() 
-							if isElement(getPedOccupiedVehicle(thePlayer)) then 
-								setVehicleWheelStates(getPedOccupiedVehicle(thePlayer), 0, 0, 0, 0) 
-							end 
-						end, 10000, 1)
+						triggerClientEvent(thePlayer, "spikesTimerFunction", root)
 						destroyElement(source)
 					end
 				end
@@ -202,9 +197,6 @@ setElementData(source, "rektBySpikes", false, true)
 setElementData(source, "boostx3", nil, true)
 triggerClientEvent(source, "unbindKeys", resourceRoot)
 triggerClientEvent(source, "hideSpikesRepairHUD", resourceRoot)
-	if isTimer(spikesTimer) then
-		killTimer(spikesTimer)
-	end
 end)
 
 addEventHandler ("onVehicleEnter", root, 
@@ -216,8 +208,12 @@ end
 
 addEvent("fixVehicle", true)
 addEventHandler("fixVehicle", root, 
-function(theVehicle) 
-fixVehicle(theVehicle)
+function(thePlayer, theVehicle, fix) 
+	if fix then
+		fixVehicle(theVehicle)
+	end
+	setVehicleWheelStates(theVehicle, 0, 0, 0, 0)
+	setElementData(thePlayer, "rektBySpikes", false, true)
 end
 )
 
@@ -234,5 +230,13 @@ addEvent("outputChatBoxForAll", true)
 addEventHandler("outputChatBoxForAll", root,
 function (thePlayer, text)
 sendClientMessage(text, root, 255, 255, 255, "bottom")
+end
+)
+
+addEvent("onPlayerPickUpRacePickup", true)
+addEventHandler("onPlayerPickUpRacePickup", root, function(pickupID, pickupType)
+	if pickupType == "repair" then
+		setElementData(source, "rektBySpikes", false, true)
+	end
 end
 )


### PR DESCRIPTION
##### Scoreboard
- animation disabled as default (looks better, fast access to scoreboad)
- show server info enabled as default
- changed server info color to green
- changed name for xml file-storage with client settings from "settings.xml" to "settings-mrgreen.xml" (so new default settings will be applied and they'll be stored in separate file for our server because all non-mrgreen servers use settings.xml as default) 
![s](http://i.imgur.com/RYSUPWo.png)

##### Coremarkers
- fixed typos
- changed boost speed for fast cars
- added missing multiplier in line 89
- fixed auto-retreading for punctured tires
- replaced forgotten local variable for tests to comment

P.S. !update scoreboard