### PR TITLE
made rankboard show 3 digits numbers in ms section

### DIFF
--- a/resources/[gameplay]/gus/rankboard_c.lua
+++ b/resources/[gameplay]/gus/rankboard_c.lua
@@ -27,7 +27,7 @@ function msToTimeStr(ms)
 	if not ms then
 		return ''
 	end
-	local centiseconds = tostring(math.floor(math.fmod(ms, 1000)/10))
+	local centiseconds = tostring(math.floor(math.fmod(ms, 1000)/1))
 	if #centiseconds == 1 then
 		centiseconds = '0' .. centiseconds
 	end

--- a/resources/[gameplay]/gus/rankboard_c.lua
+++ b/resources/[gameplay]/gus/rankboard_c.lua
@@ -29,7 +29,7 @@ function msToTimeStr(ms)
 	end
 	local centiseconds = tostring(math.floor(math.fmod(ms, 1000)/1))
 	if #centiseconds == 1 then
-		centiseconds = '0' .. centiseconds
+		centiseconds = '00' .. centiseconds
 	end
 	local s = math.floor(ms / 1000)
 	local seconds = tostring(math.fmod(s, 60))


### PR DESCRIPTION
Made rankboard show 3 digits in milliseconds section. Now people won't finish with exactly the same time anymore.
