### PR TITLE
Syncronized speedometer with others

### DIFF
--- a/resources/[gameplay]/speed-o-meter/script.lua
+++ b/resources/[gameplay]/speed-o-meter/script.lua
@@ -1,5 +1,9 @@
 function mph()
+	local target = getCameraTarget()
 	car = getPedOccupiedVehicle(getLocalPlayer())
+	if target and getElementType(target) == "vehicle" then
+		car = target
+	end
 	if car then
 		if (getVehicleType(car) == "Plane") or (getVehicleType(car) == "Boat") or (getVehicleType(car) == "Helicopter") then
 			xx,yy,zz = getElementVelocity(car)
@@ -29,7 +33,11 @@ function mph()
 end
 
 function kmh()
+	local target = getCameraTarget()
 	car = getPedOccupiedVehicle(getLocalPlayer())
+	if target and getElementType(target) == "vehicle" then
+		car = target
+	end
 	if car then
 		if (getVehicleType(car) == "Plane") or (getVehicleType(car) == "Boat") or (getVehicleType(car) == "Helicopter") then
 			xx,yy,zz = getElementVelocity(car)


### PR DESCRIPTION
Now when you spectate another player, the speedometer will show their speed instead of just 0 as it was until now.