### PR TITLE
Made horn icon visible even while spectating

### DIFF
--- a/resources/[gameplay]/gcshop/horns/horns_c.lua
+++ b/resources/[gameplay]/gcshop/horns/horns_c.lua
@@ -619,7 +619,11 @@ function createSoundForCar(car, horn)
 		setElementPosition(sound, rx, ry, rz)
 		
 		
-		local playerx, playery, playerz = getElementPosition( getPedOccupiedVehicle(localPlayer) )
+		local target = getCameraTarget()
+		local playerx, playery, playerz = getElementPosition(getPedOccupiedVehicle(localPlayer))
+		if target then
+			playerx, playery, playerz = getElementPosition(target)
+		end
 		cp_x, cp_y, cp_z = getElementPosition( car)
 		local dist = getDistanceBetweenPoints3D ( cp_x, cp_y, cp_z, playerx, playery, playerz )
 		if dist and dist < 40 and ( isLineOfSightClear(cp_x, cp_y, cp_z+1.2, playerx, playery, playerz, true, false, false, false )) then


### PR DESCRIPTION
Now when you're spectating another player and he uses his horn, the icon will show above his car (just as if he is next to you and you're not spectating him)