### PR TITLE
Made chat icon show even while spectating

### DIFF
--- a/resources/[gameplay]/gus/ktypestatus_cl.lua
+++ b/resources/[gameplay]/gus/ktypestatus_cl.lua
@@ -29,7 +29,11 @@ function chatCheckPulse()
 end
 
 function showTextIcon()
+	local target = getCameraTarget()
 	local playerx,playery,playerz = getElementPosition(localPlayer)
+	if target then
+		playerx,playery,playerz = getElementPosition(target)
+	end
 	for player, truth in pairs(chattingPlayers) do
 		
 		if (player == localPlayer) then


### PR DESCRIPTION
Now the chat icon will show above a player's car even while you're spectating him (didn't show before)