### PR TITLE
Finish messages

### DIFF
--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -193,14 +193,14 @@ function finish(rank)
 		if rewarded_Players[player].finishReward > 1 then
 			addPlayerGreencoins(player, rewarded_Players[player].finishReward)
 			
-			exports.messages:outputGameMessage(getPlayerName(player) .."#00FF00 finished ".. tostring(rank) .. suffix .." earning ".. rewarded_Players[player].finishReward .." GC", getRootElement(), nil, 0, 255, 0)
+			exports.messages:outputGameMessage(getPlayerName(player) .."#00FF00 finished ".. tostring(rank) .. suffix .." earning ".. rewarded_Players[player].finishReward .." GC", getRootElement(), nil, 0, 255, 0, false, false, true)
 			outputChatBox(prefix .."You earned ".. rewarded_Players[player].finishReward .." GC for finishing ".. tostring(rank) .. suffix ..". You now have ".. comma_value(getPlayerGreencoins(player)) .." GC.", player, 0, 255, 0, true)				
 			
 			return
 		end
 	end
 	
-	exports.messages:outputGameMessage(getPlayerName(player) .." finished ".. tostring(rank) .. suffix, getRootElement(), nil)
+	exports.messages:outputGameMessage(getPlayerName(player) .." finished ".. tostring(rank) .. suffix, getRootElement(), nil, nil, nil, nil, false, false, true)
 end
 addEventHandler("onPlayerFinish", root, finish)
 

--- a/resources/[gameplay]/messages/server.lua
+++ b/resources/[gameplay]/messages/server.lua
@@ -1,10 +1,13 @@
-function outputGameMessage(text, triggerFor, size, r, g, b)
+function outputGameMessage(text, triggerFor, size, r, g, b, priority, chat, floating)
+	if priority == nil then priority = false end
+	if chat == nil then chat = true end
+	if floating == nil then floating = true end
 	if (r == nil) and (g == nil) and (b == nil) then
 		r = 255
 		g = 255
 		b = 255
 	end	
-	triggerClientEvent(triggerFor, "onGameMessageSend", triggerFor, text,size,r, g, b)
+	triggerClientEvent(triggerFor, "onGameMessageSend", triggerFor, text,size,r, g, b, priority, chat, floating)
 end
 
 addEventHandler('onMapStarting', getRootElement(),

--- a/resources/[gameplay]/messages/test_decompiled.lua
+++ b/resources/[gameplay]/messages/test_decompiled.lua
@@ -17,7 +17,8 @@ end
 addCommandHandler('hidemsg', function() hidemsg = not hidemsg; outputChatBox('Hidemsg: ' .. tostring(hidemsg)) end)
 
 
-function outputGameMessage(tex, size, r, g, b, priority)
+function outputGameMessage(tex, size, r, g, b, priority, chat, floating)
+	if priority == nil then priority = false end
 	text = string.gsub(tex, '#%x%x%x%x%x%x', '' )
 	if size == nil then size = 2.2 end
 	if (r == nil) or (g == nil) or (b == nil) then 
@@ -26,7 +27,8 @@ function outputGameMessage(tex, size, r, g, b, priority)
 		b = 255
 	end	
 	if hidemsg then
-            outputChatBox("[Game Message] "..text,r,g,b)
+			if chat == false and priority == false then return end
+			outputChatBox("[Game Message] "..text,r,g,b)
         return
     end
 	if priority then
@@ -39,6 +41,7 @@ function outputGameMessage(tex, size, r, g, b, priority)
 			setTimer(function(localText) dxText:create(localText) localText:destroy()  end, 9000, 1, textVar)
 			return
 	end
+	if floating == false then return end
 	if lastTick then
 		k = 0
 		for i,j in pairs(textDelayTable) do 
@@ -104,8 +107,8 @@ end
 
 addEvent("onGameMessageSend", true)
 addEventHandler("onGameMessageSend", getRootElement(),
-function(text, size, r, g, b)
-	outputGameMessage(text, size, r, g, b)
+function(text, size, r, g, b, priority, chat, floating)
+	outputGameMessage(text, size, r, g, b, priority, chat, floating)
 end
 )
 


### PR DESCRIPTION
A tweak to reduce the chatbox spam when 'floating messages' is turned
off in the settings. It won't output every finished player anymore in
the chatbox, just the player itself and the amount of gc earned.